### PR TITLE
Created a UCSBDiningMenuService that gets meal times and a controller endpoint that uses that service 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
@@ -1,0 +1,51 @@
+package edu.ucsb.cs156.dining.controllers;
+
+import edu.ucsb.cs156.dining.services.UCSBDiningMenuService;
+import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.http.ResponseEntity;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "UCSBDiningMenuController")
+@RestController
+@RequestMapping("/api.ucsb.edu/dining/menu/v1")
+@Slf4j
+public class UCSBDiningMenuController extends ApiController {
+
+  @Autowired UserRepository userRepository;
+  @Autowired UCSBDiningMenuService ucsbDiningMenuService;
+
+  @Operation(summary = "Get menu times for the date and the dining commmon provided")
+  @GetMapping(value = "/{date-time}/{dining-commons-code}", produces = "application/json")
+  public ResponseEntity<String> menutimes(
+      @PathVariable("date-time") String datetime,
+      @PathVariable("dining-commons-code") String diningcommoncode
+  )
+    throws Exception {
+
+    String body = ucsbDiningMenuService.getJSON(datetime, diningcommoncode);
+
+    return ResponseEntity.ok().body(body);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
@@ -33,7 +33,6 @@ import jakarta.validation.Valid;
 @Slf4j
 public class UCSBDiningMenuController extends ApiController {
 
-  @Autowired UserRepository userRepository;
   @Autowired UCSBDiningMenuService ucsbDiningMenuService;
 
   @Operation(summary = "Get list of meals serving in given dining common on given date")

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
@@ -36,9 +36,11 @@ public class UCSBDiningMenuController extends ApiController {
   @Autowired UserRepository userRepository;
   @Autowired UCSBDiningMenuService ucsbDiningMenuService;
 
-  @Operation(summary = "Get menu times for the date and the dining commmon provided")
+  @Operation(summary = "Get list of meals serving in given dining common on given date")
+  @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping(value = "/{date-time}/{dining-commons-code}", produces = "application/json")
   public ResponseEntity<String> menutimes(
+      @Parameter(description= "date (in iso format, e.g. YYYY-mm-dd) or date-time (in iso format e.g. YYYY-mm-ddTHH:MM:SS)") 
       @PathVariable("date-time") String datetime,
       @PathVariable("dining-commons-code") String diningcommoncode
   )

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
@@ -29,7 +29,7 @@ import jakarta.validation.Valid;
 
 @Tag(name = "UCSBDiningMenuController")
 @RestController
-@RequestMapping("/api.ucsb.edu/dining/menu/v1")
+@RequestMapping("/api/diningcommons")
 @Slf4j
 public class UCSBDiningMenuController extends ApiController {
 

--- a/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
@@ -1,0 +1,77 @@
+package edu.ucsb.cs156.dining.services;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/** Service object that wraps the UCSB Dining Menu API */
+@Service
+@Slf4j
+public class UCSBDiningMenuService {
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @Value("${app.ucsb.api.consumer_key}")
+    private String apiKey;
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    public UCSBDiningMenuService(RestTemplateBuilder restTemplateBuilder) throws Exception {
+        restTemplate = restTemplateBuilder.build();
+    }
+
+    public static final String ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT =
+      "https://api.ucsb.edu/dining/menu/v1/{date-time}/{dining-common-code}";
+
+    public String getJSON(String dateTime, String diningCommonCode) throws Exception {
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      headers.set("ucsb-api-version", "1.0");
+      headers.set("ucsb-api-key", this.apiKey);
+
+      HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+      String url = ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT;
+      url.replace("{date-time}", dateTime);
+      url.replace("{dining-common-code}", diningCommonCode);
+        
+
+      log.info("url=" + url);
+
+      String retVal = "";
+      MediaType contentType = null;
+      HttpStatus statusCode = null;
+
+      ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class, dateTime, diningCommonCode);
+      contentType = re.getHeaders().getContentType();
+      statusCode = (HttpStatus) re.getStatusCode();
+      retVal = re.getBody();
+
+      log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+      return retVal;
+    }
+}
+

--- a/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
@@ -8,10 +8,6 @@ import java.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.apache.commons.lang3.tuple.Pair;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,5 +29,7 @@ spring.mvc.format.date-time=iso
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/google}}
 
+app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}
+
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=db/migration/changelog-master.json

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
@@ -60,5 +60,4 @@ public class UCSBDiningMenuControllerTests extends ControllerTestCase {
 
     assertEquals(expectedResult, responseString);
   }
-
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -33,12 +34,20 @@ public class UCSBDiningMenuControllerTests extends ControllerTestCase {
   @MockBean private UCSBDiningMenuService ucsbDiningMenuService;
 
   @Test
-  public void test_search() throws Exception {
+  public void logged_out_users_cannot_get_meal_times() throws Exception {
+        String dateTime = "2023-10-10";
+        String diningCommonCode = "ortega";
+        mockMvc.perform(get("/api/diningcommons/{dateTime}/{diningCommonsCode}", dateTime, diningCommonCode))
+                        .andExpect(status().is(403)); // logged out users can't get meal times
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void logged_in_users_can_meal_times() throws Exception {
 
     String expectedResult = "{expectedJSONResult}";
     String url = "/api/diningcommons/2023-10-10/ortega";
-    // when(ucsbDiningMenuService.getJSON("2023-10-10", "ortega"))
-    //     .thenReturn(expectedResult);
+
     when(ucsbDiningMenuService.getJSON(any(String.class), any(String.class)))
         .thenReturn(expectedResult);
 
@@ -51,4 +60,5 @@ public class UCSBDiningMenuControllerTests extends ControllerTestCase {
 
     assertEquals(expectedResult, responseString);
   }
+
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
@@ -36,7 +36,7 @@ public class UCSBDiningMenuControllerTests extends ControllerTestCase {
   public void test_search() throws Exception {
 
     String expectedResult = "{expectedJSONResult}";
-    String url = "/api.ucsb.edu/dining/menu/v1/2023-10-10/ortega";
+    String url = "/api/diningcommons/2023-10-10/ortega";
     // when(ucsbDiningMenuService.getJSON("2023-10-10", "ortega"))
     //     .thenReturn(expectedResult);
     when(ucsbDiningMenuService.getJSON(any(String.class), any(String.class)))

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
@@ -1,0 +1,54 @@
+package edu.ucsb.cs156.dining.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.dining.ControllerTestCase;
+import edu.ucsb.cs156.dining.config.SecurityConfig;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.services.UCSBDiningMenuService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@WebMvcTest(value = UCSBDiningMenuController.class)
+@Import(SecurityConfig.class)
+@AutoConfigureDataJpa
+public class UCSBDiningMenuControllerTests extends ControllerTestCase {
+
+  @MockBean UserRepository userRepository;
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private UCSBDiningMenuService ucsbDiningMenuService;
+
+  @Test
+  public void test_search() throws Exception {
+
+    String expectedResult = "{expectedJSONResult}";
+    String url = "/api.ucsb.edu/dining/menu/v1/2023-10-10/ortega";
+    // when(ucsbDiningMenuService.getJSON("2023-10-10", "ortega"))
+    //     .thenReturn(expectedResult);
+    when(ucsbDiningMenuService.getJSON(any(String.class), any(String.class)))
+        .thenReturn(expectedResult);
+
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(expectedResult, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
@@ -1,7 +1,5 @@
 package edu.ucsb.cs156.dining.services;
 
-import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -12,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -29,6 +28,9 @@ public class UCSBDiningMenuServiceTests {
 
   @Autowired private MockRestServiceServer mockRestServiceServer;
 
+  @MockBean
+  private edu.ucsb.cs156.dining.services.wiremock.WiremockService wiremockService;
+
   @Mock private RestTemplate restTemplate;
 
   @Autowired private UCSBDiningMenuService ucs;
@@ -41,8 +43,8 @@ public class UCSBDiningMenuServiceTests {
     String diningCommonCode = "ortega";
 
     String expectedURL = UCSBDiningMenuService.ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT;
-    expectedURL.replace("{date-time}", dateTime);
-    expectedURL.replace("{dining-common-code}", diningCommonCode);
+    expectedURL = expectedURL.replace("{date-time}", dateTime);
+    expectedURL = expectedURL.replace("{dining-common-code}", diningCommonCode);
 
     this.mockRestServiceServer
         .expect(requestTo(expectedURL))
@@ -56,28 +58,4 @@ public class UCSBDiningMenuServiceTests {
 
     assertEquals(expectedResult, result);
   }
-
-//   @Test
-//   public void test_getSection_not_found() throws Exception {
-//     String expectedResult = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
-
-//     String enrollCode = "08268";
-//     String quarter = "00000";
-
-//     String expectedURL =
-//         UCSBCurriculumService.SECTION_ENDPOINT
-//             .replace("{quarter}", quarter)
-//             .replace("{enrollcode}", enrollCode);
-
-//     this.mockRestServiceServer
-//         .expect(requestTo(expectedURL))
-//         .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
-//         .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
-//         .andExpect(header("ucsb-api-version", "1.0"))
-//         .andExpect(header("ucsb-api-key", apiKey))
-//         .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
-
-//     String result = ucs.getSection(enrollCode, quarter);
-//     assertEquals(expectedResult, result);
-//   }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
@@ -1,0 +1,83 @@
+package edu.ucsb.cs156.dining.services;
+
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+@RestClientTest(UCSBDiningMenuService.class)
+@AutoConfigureDataJpa
+public class UCSBDiningMenuServiceTests {
+
+  @Value("${app.ucsb.api.consumer_key}")
+  private String apiKey;
+
+  @Autowired private MockRestServiceServer mockRestServiceServer;
+
+  @Mock private RestTemplate restTemplate;
+
+  @Autowired private UCSBDiningMenuService ucs;
+
+  @Test
+  public void test_getJSON_success() throws Exception {
+    String expectedResult = "{expectedResult}";
+
+    String dateTime = "2023-10-10";
+    String diningCommonCode = "ortega";
+
+    String expectedURL = UCSBDiningMenuService.ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT;
+    expectedURL.replace("{date-time}", dateTime);
+    expectedURL.replace("{dining-common-code}", diningCommonCode);
+
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-version", "1.0"))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+    String result = ucs.getJSON(dateTime, diningCommonCode);
+
+    assertEquals(expectedResult, result);
+  }
+
+//   @Test
+//   public void test_getSection_not_found() throws Exception {
+//     String expectedResult = "{\"error\": \"Enroll code doesn't exist in that quarter.\"}";
+
+//     String enrollCode = "08268";
+//     String quarter = "00000";
+
+//     String expectedURL =
+//         UCSBCurriculumService.SECTION_ENDPOINT
+//             .replace("{quarter}", quarter)
+//             .replace("{enrollcode}", enrollCode);
+
+//     this.mockRestServiceServer
+//         .expect(requestTo(expectedURL))
+//         .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+//         .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+//         .andExpect(header("ucsb-api-version", "1.0"))
+//         .andExpect(header("ucsb-api-key", apiKey))
+//         .andRespond(withSuccess("null", MediaType.APPLICATION_JSON));
+
+//     String result = ucs.getSection(enrollCode, quarter);
+//     assertEquals(expectedResult, result);
+//   }
+}

--- a/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.dining.services;
 
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -29,7 +31,7 @@ public class UCSBDiningMenuServiceTests {
   @Autowired private MockRestServiceServer mockRestServiceServer;
 
   @MockBean
-  private edu.ucsb.cs156.dining.services.wiremock.WiremockService wiremockService;
+  private WiremockService wiremockService;
 
   @Mock private RestTemplate restTemplate;
 


### PR DESCRIPTION
Closes #15 
Created a UCSBDiningMenuService that receives info from https://api.ucsb.edu/dining/menu/v1/{datetime}/{diningcommoncode}.

The controller endpoint /api/diningcommons/{date-time}/{dining-commons-code} uses that service which returns meal times on a certain day at a certain dining common.

<img width="1399" alt="Screenshot 2024-11-19 at 3 37 41 PM" src="https://github.com/user-attachments/assets/0e0130b5-a26f-40e7-a1e0-32106562b58b">
Can be tested at (have to be logged in to use this controller): https://proj-dining-li-kelly.dokku-16.cs.ucsb.edu 

Should work the same as: https://developer.ucsb.edu/apis/dining/dining-menu#/menu/GetMealsServing