### PR TITLE
Epic 3 Backend 2: Created a service and controller that uses it which returns the items on the menu

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.dining.services.UCSBDiningMenuItemsService;
 import edu.ucsb.cs156.dining.models.Entree;
 
 import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,9 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.http.ResponseEntity;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import org.springframework.format.annotation.DateTimeFormat;
+
 import java.util.List;
 
 import jakarta.validation.Valid;

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
@@ -1,0 +1,52 @@
+package edu.ucsb.cs156.dining.controllers;
+
+import edu.ucsb.cs156.dining.services.UCSBDiningMenuItemsService;
+import edu.ucsb.cs156.dining.models.Entree;
+
+import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.http.ResponseEntity;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "UCSBDiningMenuItems")
+@RestController
+@RequestMapping("/api/diningcommons")
+@Slf4j
+public class UCSBDiningMenuItemsController extends ApiController {
+
+  @Autowired UCSBDiningMenuItemsService ucsbDiningMenuItemsService;
+
+  @Operation(summary = "Get list of entrees being served at given meal, dining common, and day")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping(value = "/{date-time}/{dining-commons-code}/{meal-code}", produces = "application/json")
+  public ResponseEntity<List<Entree>> get_menu_items(
+      @Parameter(description= "date (in iso format, e.g. YYYY-mm-dd) or date-time (in iso format e.g. YYYY-mm-ddTHH:MM:SS)") 
+      @PathVariable("date-time") String datetime,
+      @PathVariable("dining-commons-code") String diningcommoncode,
+      @PathVariable("meal-code") String mealcode
+  )
+    throws Exception {
+
+    List<Entree> body = ucsbDiningMenuItemsService.get(datetime, diningcommoncode, mealcode);
+
+    return ResponseEntity.ok().body(body);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/dining/models/Entree.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/Entree.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.dining.models;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Entree {
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsService.java
@@ -1,0 +1,71 @@
+package edu.ucsb.cs156.dining.services;
+
+import edu.ucsb.cs156.dining.models.Entree;
+
+import java.util.Arrays;
+import java.util.List;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class UCSBDiningMenuItemsService {
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @Value("${app.ucsb.api.consumer_key}")
+    private String apiKey;
+
+    private RestTemplate restTemplate = new RestTemplate();
+
+    public UCSBDiningMenuItemsService(RestTemplateBuilder restTemplateBuilder) throws Exception {
+        restTemplate = restTemplateBuilder.build();
+    }
+
+    public static final String ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT =
+      "https://api.ucsb.edu/dining/menu/v1/{date-time}/{dining-common-code}/{meal-code}";
+
+    /**
+   * Create a List of Entree from json representation
+   * @param dateTime String of date in iso format
+   * @param diningCommonCode String of dining common 
+   * @param mealCode String of meal code
+   * @return a list of menu items
+   */
+
+    public List<Entree> get(String dateTime, String diningCommonCode, String mealCode) throws JsonProcessingException {
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("ucsb-api-key", this.apiKey);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        String url = ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT;
+        url = url.replace("{date-time}", dateTime);
+        url = url.replace("{dining-common-code}", diningCommonCode);
+        url = url.replace("{meal-code}", mealCode);
+
+        ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        String retBody = re.getBody();
+
+        List<Entree> menuItems = objectMapper.readValue(retBody, new TypeReference<List<Entree>>() {});
+
+        return menuItems;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,5 +29,7 @@ spring.mvc.format.date-time=iso
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/google}}
 
+app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}
+
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=db/migration/changelog-master.json

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -1,0 +1,112 @@
+package edu.ucsb.cs156.dining.controllers;
+
+import edu.ucsb.cs156.dining.models.Entree;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.dining.ControllerTestCase;
+import edu.ucsb.cs156.dining.config.SecurityConfig;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.services.UCSBDiningMenuItemsService;
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+@WebMvcTest(value = UCSBDiningMenuItemsController.class)
+@Import(SecurityConfig.class)
+@AutoConfigureDataJpa
+public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private UCSBDiningMenuItemsService ucsbDiningMenuItemsService;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  private static final String NAME = "NAME";
+  private static final String STATION = "STATION";
+
+  @Test
+  public void logged_out_users_cannot_get_meal_items() throws Exception {
+        String dateTime = "2023-10-10";
+        String diningCommonCode = "ortega";
+        String mealCode = "lunch";
+        mockMvc.perform(get("/api/diningcommons/{dateTime}/{diningCommonsCode}/{lunch}", dateTime, diningCommonCode, mealCode))
+                        .andExpect(status().is(403)); // logged out users can't get meal times
+  }
+
+  @WithMockUser(roles = { "USER" })
+  @Test
+  public void logged_in_users_can_get_meal_items() throws Exception {
+
+    String dateTime = "2023-10-10";
+    String diningCommonCode = "ortega";
+    String mealCode = "lunch";
+
+    String readat = UCSBDiningMenuItemsService.ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT;
+    readat = readat.replace("{date-time}", dateTime);
+    readat = readat.replace("{dining-common-code}", diningCommonCode);
+    readat = readat.replace("{meal-code}", mealCode);
+
+    String jsonResponse =
+      String.format(
+          """
+              [
+                {
+                  \"name\": \"%s\",
+                  \"station\":\"%s\"
+                }
+              ]
+          """,
+          NAME,
+          STATION);
+    
+    List<Entree> expectedResult = new ArrayList<Entree>();
+
+    JsonNode rootNode = objectMapper.readTree(jsonResponse);
+    Iterator<JsonNode> elements = rootNode.elements();
+
+    while (elements.hasNext()) {
+        JsonNode element = elements.next();
+  
+        Entree meal = Entree.builder()
+            .name(element.get("name").asText())
+            .station(element.get("station").asText())
+            .build();
+        expectedResult.add(meal);
+    }
+
+    String url = "/api/diningcommons/2023-10-10/ortega/lunch";
+
+    when(ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode)).thenReturn(expectedResult);
+
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    assertEquals(
+        expectedResult,
+        objectMapper.readValue(
+            response.getResponse().getContentAsString(),
+            new TypeReference<List<Entree>>() {}));
+  }
+}
+

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.config.SecurityConfig;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
 import edu.ucsb.cs156.dining.services.UCSBDiningMenuItemsService;
 import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -48,7 +47,7 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
         String diningCommonCode = "ortega";
         String mealCode = "lunch";
         mockMvc.perform(get("/api/diningcommons/{dateTime}/{diningCommonsCode}/{lunch}", dateTime, diningCommonCode, mealCode))
-                        .andExpect(status().is(403)); // logged out users can't get meal times
+                        .andExpect(status().is(403)); // logged out users can't get meal items
   }
 
   @WithMockUser(roles = { "USER" })

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -59,11 +59,6 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
     String diningCommonCode = "ortega";
     String mealCode = "lunch";
 
-    String readat = UCSBDiningMenuItemsService.ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT;
-    readat = readat.replace("{date-time}", dateTime);
-    readat = readat.replace("{dining-common-code}", diningCommonCode);
-    readat = readat.replace("{meal-code}", mealCode);
-
     String jsonResponse =
       String.format(
           """

--- a/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsServiceTests.java
@@ -1,0 +1,87 @@
+package edu.ucsb.cs156.dining.services;
+
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
+import edu.ucsb.cs156.dining.models.Entree;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+@RestClientTest(UCSBDiningMenuItemsService.class)
+@AutoConfigureDataJpa
+public class UCSBDiningMenuItemsServiceTests {
+
+  @Value("${app.ucsb.api.consumer_key}")
+  private String apiKey;
+
+  @Autowired private MockRestServiceServer mockRestServiceServer;
+
+  @MockBean
+  private WiremockService wiremockService;
+
+  @Mock private RestTemplate restTemplate;
+
+  @Autowired private UCSBDiningMenuItemsService ucsbDiningMenuItemsService;
+
+  private static final String NAME = "NAME";
+  private static final String STATION = "STATION";
+
+  @Test
+  void test_get_success() throws Exception {
+
+    String dateTime = "2023-10-10";
+    String diningCommonCode = "ortega";
+    String mealCode = "lunch";
+
+    String expectedURL = UCSBDiningMenuItemsService.ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT;
+    expectedURL = expectedURL.replace("{date-time}", dateTime);
+    expectedURL = expectedURL.replace("{dining-common-code}", diningCommonCode);
+    expectedURL = expectedURL.replace("{meal-code}", mealCode);
+
+    String expectedResult =
+        String.format(
+            """
+                [
+                  {
+                    \"name\": \"%s\",
+                    \"station\":\"%s\"
+                  }
+                ]
+            """,
+            NAME,
+            STATION);
+
+    Entree expectedEntree = Entree.builder()
+        .name(NAME)
+        .station(STATION)
+        .build();
+
+    this.mockRestServiceServer
+        .expect(requestTo(expectedURL))
+        .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+        .andExpect(header("ucsb-api-key", apiKey))
+        .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
+
+    List<Entree> actualResult = ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode);
+    List<Entree> expectedList = new ArrayList<>();
+    expectedList.addAll(Arrays.asList(expectedEntree));
+    assertEquals(expectedList, actualResult);
+  }
+}


### PR DESCRIPTION
Closes #16 
Created a UCSBDiningMenuItemsService that returns a list of items on the menu after given the date, dining common, and meal time. The list of items return is in the form of the model I created called Entree. 
<img width="1153" alt="Screenshot 2024-11-21 at 2 33 40 PM" src="https://github.com/user-attachments/assets/5f5df24f-b3a1-4b2d-92d3-451cce396837">

Can be tested at (must be logged in): https://pj-getmenuitems-li-kelly.dokku-16.cs.ucsb.edu/
Using the same inputs it should output the same menu items as: https://developer.ucsb.edu/apis/dining/dining-menu#/menu/GetMenu

Note: if a previous PR that got merged into main has already changed application properties to add the api key then I should just rebase it and it shouldn't be changed again in this PR.