### PR TITLE
Sa moderate placeholderpage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,8 @@ import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
 import MyReviewsIndexPage from "main/pages/MyReviews/MyReviewsIndexPage";
 
+import Moderate from "main/pages/Moderate";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -43,6 +45,10 @@ function App() {
           <>
             <Route exact path="/myreviews" element={<MyReviewsIndexPage />} />
           </>
+        )}
+
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <Route exact path="/moderate" element={<Moderate />} />
         )}
 
         {hasRole(currentUser, "ROLE_ADMIN") && (

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -50,13 +50,20 @@ export default function AppNavbar({
           <Navbar.Collapse className="justify-content-between">
             <Nav className="mr-auto">
               {hasRole(currentUser, "ROLE_ADMIN") && (
-                <NavDropdown
-                  title="Admin"
-                  id="appnavbar-admin-dropdown"
-                  data-testid="appnavbar-admin-dropdown"
-                >
-                  <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
-                </NavDropdown>
+                <>
+                  <NavDropdown
+                    title="Admin"
+                    id="appnavbar-admin-dropdown"
+                    data-testid="appnavbar-admin-dropdown"
+                  >
+                    <NavDropdown.Item href="/admin/users">
+                      Users
+                    </NavDropdown.Item>
+                  </NavDropdown>
+                  <Nav.Link as={Link} to="/moderate">
+                    Moderate
+                  </Nav.Link>
+                </>
               )}
               {currentUser && currentUser.loggedIn ? (
                 <>

--- a/frontend/src/main/pages/Moderate.js
+++ b/frontend/src/main/pages/Moderate.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Navigate } from "react-router-dom";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+const Moderate = () => {
+  const { data: currentUser } = useCurrentUser();
+
+  if (!currentUser.loggedIn || !hasRole(currentUser, "ROLE_ADMIN")) {
+    return <Navigate to="/" />;
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Moderation Page</h1>
+        <p>This page is accessible only to admins. (Placeholder)</p>
+      </div>
+    </BasicLayout>
+  );
+};
+
+export default Moderate;

--- a/frontend/src/tests/pages/Moderate.test.js
+++ b/frontend/src/tests/pages/Moderate.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
@@ -9,16 +9,14 @@ describe("ModeratePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
   const queryClient = new QueryClient();
 
-  const renderPage = async () => {
-    await act(async () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <Moderate />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-    });
+  const renderPage = () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <Moderate />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
   };
 
   beforeEach(() => {
@@ -36,16 +34,16 @@ describe("ModeratePage tests", () => {
       .onGet("/api/systemInfo")
       .reply(200, { springH2ConsoleEnabled: false });
 
-    await renderPage();
+    renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText("Moderation Page")).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          "This page is accessible only to admins. (Placeholder)",
-        ),
-      ).toBeInTheDocument();
-    });
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.getByText("Moderation Page")).toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
+    expect(
+      screen.getByText("This page is accessible only to admins. (Placeholder)"),
+    ).toBeInTheDocument();
   });
 
   test("redirects non-admin user to homepage", async () => {
@@ -57,16 +55,18 @@ describe("ModeratePage tests", () => {
       .onGet("/api/systemInfo")
       .reply(200, { springH2ConsoleEnabled: false });
 
-    await renderPage();
+    renderPage();
 
-    await waitFor(() => {
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText(
-          "This page is accessible only to admins. (Placeholder)",
-        ),
-      ).not.toBeInTheDocument();
-    });
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
+    expect(
+      screen.queryByText(
+        "This page is accessible only to admins. (Placeholder)",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   test("redirects to homepage if currentUser is undefined", async () => {
@@ -75,16 +75,18 @@ describe("ModeratePage tests", () => {
       .onGet("/api/systemInfo")
       .reply(200, { springH2ConsoleEnabled: false });
 
-    await renderPage();
+    renderPage();
 
-    await waitFor(() => {
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText(
-          "This page is accessible only to admins. (Placeholder)",
-        ),
-      ).not.toBeInTheDocument();
-    });
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
+    expect(
+      screen.queryByText(
+        "This page is accessible only to admins. (Placeholder)",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   test("redirects to homepage if currentUser.loggedIn is undefined", async () => {
@@ -95,16 +97,18 @@ describe("ModeratePage tests", () => {
       .onGet("/api/systemInfo")
       .reply(200, { springH2ConsoleEnabled: false });
 
-    await renderPage();
+    renderPage();
 
-    await waitFor(() => {
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText(
-          "This page is accessible only to admins. (Placeholder)",
-        ),
-      ).not.toBeInTheDocument();
-    });
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
+    expect(
+      screen.queryByText(
+        "This page is accessible only to admins. (Placeholder)",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   test("handles case where currentUser is null and skips hasRole", async () => {
@@ -115,15 +119,17 @@ describe("ModeratePage tests", () => {
       .onGet("/api/systemInfo")
       .reply(200, { springH2ConsoleEnabled: false });
 
-    await renderPage();
+    renderPage();
 
-    await waitFor(() => {
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
-      expect(
-        screen.queryByText(
-          "This page is accessible only to admins. (Placeholder)",
-        ),
-      ).not.toBeInTheDocument();
-    });
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
+    expect(
+      screen.queryByText(
+        "This page is accessible only to admins. (Placeholder)",
+      ),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/Moderate.test.js
+++ b/frontend/src/tests/pages/Moderate.test.js
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
@@ -36,13 +36,11 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    // Single assertion inside waitFor
-    await waitFor(() =>
-      expect(screen.getByText("Moderation Page")).toBeInTheDocument(),
-    );
-    // Additional assertion outside waitFor
+    expect(await screen.findByText("Moderation Page")).toBeInTheDocument();
     expect(
-      screen.getByText("This page is accessible only to admins. (Placeholder)"),
+      await screen.findByText(
+        "This page is accessible only to admins. (Placeholder)",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -57,11 +55,9 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    // Single assertion inside waitFor
-    await waitFor(() =>
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
-    );
-    // Additional assertion outside waitFor
+    expect(
+      await screen.queryByText("Moderation Page"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",
@@ -77,11 +73,9 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    // Single assertion inside waitFor
-    await waitFor(() =>
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
-    );
-    // Additional assertion outside waitFor
+    expect(
+      await screen.queryByText("Moderation Page"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",
@@ -99,11 +93,9 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    // Single assertion inside waitFor
-    await waitFor(() =>
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
-    );
-    // Additional assertion outside waitFor
+    expect(
+      await screen.queryByText("Moderation Page"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",
@@ -121,11 +113,9 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    // Single assertion inside waitFor
-    await waitFor(() =>
-      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
-    );
-    // Additional assertion outside waitFor
+    expect(
+      await screen.queryByText("Moderation Page"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",

--- a/frontend/src/tests/pages/Moderate.test.js
+++ b/frontend/src/tests/pages/Moderate.test.js
@@ -1,0 +1,129 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import Moderate from "main/pages/Moderate";
+
+describe("ModeratePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const queryClient = new QueryClient();
+
+  const renderPage = async () => {
+    await act(async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <Moderate />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+
+  test("renders correctly for admin user", async () => {
+    axiosMock.onGet("/api/currentUser").reply(200, {
+      user: { id: 1, email: "admin@ucsb.edu", admin: true },
+      roles: [{ authority: "ROLE_ADMIN" }],
+    });
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, { springH2ConsoleEnabled: false });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Moderation Page")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "This page is accessible only to admins. (Placeholder)",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("redirects non-admin user to homepage", async () => {
+    axiosMock.onGet("/api/currentUser").reply(200, {
+      user: { id: 2, email: "user@ucsb.edu", admin: false },
+      roles: [{ authority: "ROLE_USER" }],
+    });
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, { springH2ConsoleEnabled: false });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "This page is accessible only to admins. (Placeholder)",
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("redirects to homepage if currentUser is undefined", async () => {
+    axiosMock.onGet("/api/currentUser").reply(200, null);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, { springH2ConsoleEnabled: false });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "This page is accessible only to admins. (Placeholder)",
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("redirects to homepage if currentUser.loggedIn is undefined", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, { loggedIn: undefined, root: null });
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, { springH2ConsoleEnabled: false });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "This page is accessible only to admins. (Placeholder)",
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("handles case where currentUser is null and skips hasRole", async () => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, { loggedIn: false, root: null });
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, { springH2ConsoleEnabled: false });
+
+    await renderPage();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "This page is accessible only to admins. (Placeholder)",
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/tests/pages/Moderate.test.js
+++ b/frontend/src/tests/pages/Moderate.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
@@ -36,11 +36,11 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    expect(await screen.findByText("Moderation Page")).toBeInTheDocument();
+    // Single assertion inside waitFor
+    await screen.findByText("Moderation Page");
+    // Additional assertion outside waitFor
     expect(
-      await screen.findByText(
-        "This page is accessible only to admins. (Placeholder)",
-      ),
+      screen.getByText("This page is accessible only to admins. (Placeholder)"),
     ).toBeInTheDocument();
   });
 
@@ -55,9 +55,11 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    expect(
-      await screen.queryByText("Moderation Page"),
-    ).not.toBeInTheDocument();
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",
@@ -73,9 +75,11 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    expect(
-      await screen.queryByText("Moderation Page"),
-    ).not.toBeInTheDocument();
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",
@@ -93,9 +97,11 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    expect(
-      await screen.queryByText("Moderation Page"),
-    ).not.toBeInTheDocument();
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",
@@ -113,9 +119,11 @@ describe("ModeratePage tests", () => {
 
     renderPage();
 
-    expect(
-      await screen.queryByText("Moderation Page"),
-    ).not.toBeInTheDocument();
+    // Single assertion inside waitFor
+    await waitFor(() =>
+      expect(screen.queryByText("Moderation Page")).not.toBeInTheDocument(),
+    );
+    // Additional assertion outside waitFor
     expect(
       screen.queryByText(
         "This page is accessible only to admins. (Placeholder)",


### PR DESCRIPTION
Closes #27 

This PR adds a link called "Moderate" to the navbar that is only visible to logged in admin users. The link redirects to /moderate which has a placeholder page.

![Screenshot 2024-11-21 225906](https://github.com/user-attachments/assets/cab4dd63-704e-4f2b-8691-cce8f257ed1b)
![Screenshot 2024-11-21 225720](https://github.com/user-attachments/assets/3d9bf4e6-b93b-4ef3-8175-1c96e51e9851)
![Screenshot 2024-11-21 225650](https://github.com/user-attachments/assets/a36bf821-3bb0-4c6a-9cce-22991a7eca29)


The feature can be viewed here:

https://proj-dining-salshriaan.dokku-16.cs.ucsb.edu/