### PR TITLE
created database for menu items

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
@@ -41,7 +41,6 @@ public class UCSBDiningMenuItemsController extends ApiController {
   @Operation(summary = "Get list of entrees being served at given meal, dining common, and day")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping(value = "/{date-time}/{dining-commons-code}/{meal-code}", produces = "application/json")
-  // public ResponseEntity<List<Entree>> get_menu_items(
   public ResponseEntity<List<MenuItem>> get_menu_items(
       @Parameter(description= "date (in iso format, e.g. YYYY-mm-dd) or date-time (in iso format e.g. YYYY-mm-ddTHH:MM:SS)") 
       @PathVariable("date-time") String datetime,
@@ -67,8 +66,7 @@ public class UCSBDiningMenuItemsController extends ApiController {
           menuItemRepository.save(newMenuItem);
           menuitems.add(newMenuItem);
     }
-    
-    // return ResponseEntity.ok().body(body);
+
     return ResponseEntity.ok().body(menuitems);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.dining.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+/** 
+ * This is a JPA entity that represents a MenuItem
+ * 
+ * A MenuItem represents a actual menu item in a dining commons at UCSB
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitem")
+public class MenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  
+  private String diningCommonsCode;
+  private String mealCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/dining/repositories/MenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/dining/repositories/MenuItemRepository.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs156.dining.repositories;
+
+import edu.ucsb.cs156.dining.entities.MenuItem;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+@Repository
+public interface MenuItemRepository extends CrudRepository<MenuItem, Long> {
+  /**
+   * This method returns a MenuItem entity with a given id.
+   * @param id of menu item
+   * @return Optional of Menu item based on the parameters (empty if not found)
+   */
+  Optional<MenuItem> findByDiningCommonsCodeAndMealCodeAndNameAndStation(String diningCommonsCode, String mealCode, String name, String station);
+}

--- a/src/main/java/edu/ucsb/cs156/dining/repositories/MenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/dining/repositories/MenuItemRepository.java
@@ -11,7 +11,10 @@ import java.util.Optional;
 public interface MenuItemRepository extends CrudRepository<MenuItem, Long> {
   /**
    * This method returns a MenuItem entity with a given id.
-   * @param id of menu item
+   * @param diningCommonsCode of menu item
+   * @param mealCode of menu item
+   * @param name of menu item
+   * @param station of menu item
    * @return Optional of Menu item based on the parameters (empty if not found)
    */
   Optional<MenuItem> findByDiningCommonsCodeAndMealCodeAndNameAndStation(String diningCommonsCode, String mealCode, String name, String station);

--- a/src/main/resources/db/migration/changes/MenuItem.json
+++ b/src/main/resources/db/migration/changes/MenuItem.json
@@ -1,0 +1,68 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "menuitem-1",
+          "author": "KellyL",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "menuitem"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEM_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "MEAL_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "menuitem"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -1,11 +1,20 @@
 package edu.ucsb.cs156.dining.controllers;
 
 import edu.ucsb.cs156.dining.models.Entree;
+import edu.ucsb.cs156.dining.entities.MenuItem;
+import edu.ucsb.cs156.dining.repositories.MenuItemRepository;
+import edu.ucsb.cs156.dining.controllers.UCSBDiningMenuItemsController;
+// import edu.ucsb.cs156.dining.dto.MenuItemDTO;
+
+import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import org.springframework.http.MediaType;
+import static org.mockito.Mockito.verify;
 
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.config.SecurityConfig;
@@ -22,6 +31,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import static org.mockito.Mockito.times;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.ArrayList;
@@ -38,6 +48,9 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
 
   @Autowired private ObjectMapper objectMapper;
 
+  @MockBean
+  MenuItemRepository menuItemRepository;
+
   private static final String NAME = "NAME";
   private static final String STATION = "STATION";
 
@@ -46,61 +59,113 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
         String dateTime = "2023-10-10";
         String diningCommonCode = "ortega";
         String mealCode = "lunch";
-        mockMvc.perform(get("/api/diningcommons/{dateTime}/{diningCommonsCode}/{lunch}", dateTime, diningCommonCode, mealCode))
+        mockMvc.perform(get("/api/diningcommons/{dateTime}/{diningCommonsCode}/{mealCode}", dateTime, diningCommonCode, mealCode))
                         .andExpect(status().is(403)); // logged out users can't get meal items
   }
 
+  // @WithMockUser(roles = { "USER" })
+  // @Test
+  // public void logged_in_users_can_get_meal_items() throws Exception {
+
+  //   String dateTime = "2023-10-10";
+  //   String diningCommonCode = "ortega";
+  //   String mealCode = "lunch";
+
+  //   String jsonResponse =
+  //     String.format(
+  //         """
+  //             [
+  //               {
+  //                 \"name\": \"%s\",
+  //                 \"station\":\"%s\"
+  //               }
+  //             ]
+  //         """,
+  //         NAME,
+  //         STATION);
+    
+  //   List<Entree> expectedResult = new ArrayList<Entree>();
+
+  //   JsonNode rootNode = objectMapper.readTree(jsonResponse);
+  //   Iterator<JsonNode> elements = rootNode.elements();
+
+  //   while (elements.hasNext()) {
+  //       JsonNode element = elements.next();
+  
+  //       Entree meal = Entree.builder()
+  //           .name(element.get("name").asText())
+  //           .station(element.get("station").asText())
+  //           .build();
+  //       expectedResult.add(meal);
+  //   }
+
+  //   String url = "/api/diningcommons/2023-10-10/ortega/lunch";
+
+  //   when(ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode)).thenReturn(expectedResult);
+
+  //   MvcResult response =
+  //       mockMvc
+  //           .perform(get(url).contentType("application/json"))
+  //           .andExpect(status().isOk())
+  //           .andReturn();
+
+  //   assertEquals(
+  //       expectedResult,
+  //       objectMapper.readValue(
+  //           response.getResponse().getContentAsString(),
+  //           new TypeReference<List<Entree>>() {}));
+  // }
+
   @WithMockUser(roles = { "USER" })
   @Test
-  public void logged_in_users_can_get_meal_items() throws Exception {
+  public void meal_item_exists() throws Exception {
+    String dateTime = "2023-10-11";
+    String diningCommonCode = "portola";
+    String mealCode = "dinner";
+    String name = "Spicy Tuna Roll";
+    String station = "International";
 
-    String dateTime = "2023-10-10";
-    String diningCommonCode = "ortega";
-    String mealCode = "lunch";
+    Entree entree = new Entree(name, station);
+        List<Entree> entrees = new ArrayList<>();
+        entrees.add(entree);
 
-    String jsonResponse =
-      String.format(
-          """
-              [
-                {
-                  \"name\": \"%s\",
-                  \"station\":\"%s\"
-                }
-              ]
-          """,
-          NAME,
-          STATION);
-    
-    List<Entree> expectedResult = new ArrayList<Entree>();
+    when(ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode))
+            .thenReturn(entrees);
 
-    JsonNode rootNode = objectMapper.readTree(jsonResponse);
-    Iterator<JsonNode> elements = rootNode.elements();
+    when(menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(diningCommonCode, mealCode, name, station))
+        .thenReturn(Optional.empty());
 
-    while (elements.hasNext()) {
-        JsonNode element = elements.next();
+    when(menuItemRepository.save(any(MenuItem.class))).thenAnswer(invocation -> {
+      MenuItem menuItem = invocation.getArgument(0);
+      menuItem.setId(1L);  // Mock the ID after saving
+      return menuItem;
+    });
+
+    MvcResult result = mockMvc.perform(get("/api/diningcommons/2023-10-11/portola/dinner")
+          .contentType(MediaType.APPLICATION_JSON))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$[0].name").value(name))
+          .andReturn();
+
+    String responseBody = result.getResponse().getContentAsString();
+
+    List<MenuItem> menuItems = objectMapper.readValue(responseBody, new TypeReference<List<MenuItem>>(){});
   
-        Entree meal = Entree.builder()
-            .name(element.get("name").asText())
-            .station(element.get("station").asText())
-            .build();
-        expectedResult.add(meal);
+    for(MenuItem item : menuItems){
+        menuItemRepository.save(item);
+
+      // assertEquals(item.getDiningCommonsCode(), "portola");
+      // assertEquals(item.getMealCode(), "dinner");
+
+      when(menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(diningCommonCode, mealCode, name, station))
+            .thenReturn(Optional.of(new MenuItem(1L, diningCommonCode, mealCode, name, station)));
+
+      assertEquals(item.getDiningCommonsCode(), "portola");
+      assertEquals(item.getMealCode(), "dinner");
+      assertEquals(item.getStation(), "International");
     }
 
-    String url = "/api/diningcommons/2023-10-10/ortega/lunch";
-
-    when(ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode)).thenReturn(expectedResult);
-
-    MvcResult response =
-        mockMvc
-            .perform(get(url).contentType("application/json"))
-            .andExpect(status().isOk())
-            .andReturn();
-
-    assertEquals(
-        expectedResult,
-        objectMapper.readValue(
-            response.getResponse().getContentAsString(),
-            new TypeReference<List<Entree>>() {}));
+    Optional<MenuItem> found = menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(diningCommonCode, mealCode, name, station);
+    assertTrue(found.isPresent());
   }
 }
-

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -137,7 +137,7 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
 
     when(menuItemRepository.save(any(MenuItem.class))).thenAnswer(invocation -> {
       MenuItem menuItem = invocation.getArgument(0);
-      menuItem.setId(1L);  // Mock the ID after saving
+      menuItem.setId(1L);
       return menuItem;
     });
 
@@ -153,9 +153,6 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
   
     for(MenuItem item : menuItems){
         menuItemRepository.save(item);
-
-      // assertEquals(item.getDiningCommonsCode(), "portola");
-      // assertEquals(item.getMealCode(), "dinner");
 
       when(menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(diningCommonCode, mealCode, name, station))
             .thenReturn(Optional.of(new MenuItem(1L, diningCommonCode, mealCode, name, station)));

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.dining.models.Entree;
 import edu.ucsb.cs156.dining.entities.MenuItem;
 import edu.ucsb.cs156.dining.repositories.MenuItemRepository;
 import edu.ucsb.cs156.dining.controllers.UCSBDiningMenuItemsController;
-// import edu.ucsb.cs156.dining.dto.MenuItemDTO;
 
 import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,62 +62,9 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
                         .andExpect(status().is(403)); // logged out users can't get meal items
   }
 
-  // @WithMockUser(roles = { "USER" })
-  // @Test
-  // public void logged_in_users_can_get_meal_items() throws Exception {
-
-  //   String dateTime = "2023-10-10";
-  //   String diningCommonCode = "ortega";
-  //   String mealCode = "lunch";
-
-  //   String jsonResponse =
-  //     String.format(
-  //         """
-  //             [
-  //               {
-  //                 \"name\": \"%s\",
-  //                 \"station\":\"%s\"
-  //               }
-  //             ]
-  //         """,
-  //         NAME,
-  //         STATION);
-    
-  //   List<Entree> expectedResult = new ArrayList<Entree>();
-
-  //   JsonNode rootNode = objectMapper.readTree(jsonResponse);
-  //   Iterator<JsonNode> elements = rootNode.elements();
-
-  //   while (elements.hasNext()) {
-  //       JsonNode element = elements.next();
-  
-  //       Entree meal = Entree.builder()
-  //           .name(element.get("name").asText())
-  //           .station(element.get("station").asText())
-  //           .build();
-  //       expectedResult.add(meal);
-  //   }
-
-  //   String url = "/api/diningcommons/2023-10-10/ortega/lunch";
-
-  //   when(ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode)).thenReturn(expectedResult);
-
-  //   MvcResult response =
-  //       mockMvc
-  //           .perform(get(url).contentType("application/json"))
-  //           .andExpect(status().isOk())
-  //           .andReturn();
-
-  //   assertEquals(
-  //       expectedResult,
-  //       objectMapper.readValue(
-  //           response.getResponse().getContentAsString(),
-  //           new TypeReference<List<Entree>>() {}));
-  // }
-
   @WithMockUser(roles = { "USER" })
   @Test
-  public void meal_item_exists() throws Exception {
+  public void meal_item_created_and_found() throws Exception {
     String dateTime = "2023-10-11";
     String diningCommonCode = "portola";
     String mealCode = "dinner";


### PR DESCRIPTION
Closes #17 
Created the database to store MenuItem. Modified the controller so that every time a menu item is retrieved through the get function, it adds it to the database. If the unique (same dining common, meal code) menu item is already in the database it won't be readded and the id should be the same. The printed output shows you the ids of menu items and how they don't change if it's the same. 

Can be tested here: https://pj-getmenuitems-li-kelly.dokku-16.cs.ucsb.edu
For example if you input: 
**2023-10-10 ortega lunch** you get that "Fries (vgn)" has an id of 21 
**2024-10-10 ortega lunch** "Fries (vgn)" should still have an id of 21 
however once you change the meal code 
**2024-10-10 ortega dinner** "Fries (vgn)" will have a new id